### PR TITLE
make default_url_pattern configurable

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -19,7 +19,7 @@
 class mailman::config inherits mailman::params {
   $default_url_host         = $mailman::http_hostname
   $default_email_host       = $mailman::default_email_host
-  $default_url_pattern      = 'http://%s/mailman/'
+  $default_url_pattern      = $mailman::default_url_pattern
   $mailman_site_list        = $mailman::mailman_site_list
   $language                 = $mailman::language
   $mta                      = $mailman::mta

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -106,6 +106,7 @@ class mailman (
   $archive_dir           = $mailman::params::archive_dir,
   $pid_file              = $mailman::params::pid_file,
   $option_hash           = { 'DEFAULT_MAX_NUM_RECIPIENTS' => 20 },
+  $default_url_pattern   = $mailman::params::default_url_pattern,
 ) inherits mailman::params {
   $langs = ['ar','ca','cs','da','de','en','es','et','eu','fi','fr','gl','he',
     'hr','hu','ia','it','ja','ko','lt','nl','no','pl','pt','pt_BR','ro',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,6 +30,7 @@
 class mailman::params {
   $mm_package = 'mailman'
   $mm_service = 'mailman'
+  $default_url_pattern = 'http://%s/mailman/'
   case $::osfamily {
     'RedHat': {
       $mm_username   = 'mailman'


### PR DESCRIPTION
Currently this is the only setting buried as a static param in `mailman::config`. Moved this to a global init class param with the default set in the params class.